### PR TITLE
Tagged Dragon Armor with Trimmable_Armor tag

### DIFF
--- a/src/main/resources/data/minecraft/tags/items/trimmable_armor.json
+++ b/src/main/resources/data/minecraft/tags/items/trimmable_armor.json
@@ -1,0 +1,10 @@
+{
+  "replace": false,
+  "values": [
+    "dragonloot:dragon_helmet",
+    "dragonloot:dragon_chestplate",
+    "dragonloot:dragon_leggings",
+    "dragonloot:dragon_boots",
+    "dragonloot:upgraded_dragon_chestplate"
+  ]
+}


### PR DESCRIPTION
NOTE: 2D item sprite does not update with changes, but this appears to work just fine for the 3D appearance, and the armor updates correctly. 

It took me a while to find this really simple looking solution, since I am new to Fabric modding and it appears that this mod is not using Datagen which is typical for newer versions of Fabric.